### PR TITLE
Add packaging, development and best practices episodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ serve:
 
 podman:
 	podman run -it --replace --name efficient-julia -v $$(pwd):/lesson --security-opt label=disable --network=host sandpaper
+
+docker:
+	docker run -it --name efficient-julia -v $$(pwd):/lesson --security-opt label=disable --network=host sandpaper
+

--- a/episodes/070-pkg.md
+++ b/episodes/070-pkg.md
@@ -157,6 +157,41 @@ If we check `pkg> status` again, we see that we have returned to the "(empty pro
 pkg> status
 ```
 
+:::challenge
+#### Add and remove the Dates package (3 min)
+
+There is a `Dates` standard Julia package. Try adding this as a dependency, then check `Project.toml` and `Manifest.toml` to see what has changed.
+
+Then remove the `Dates` dependency when you are done.
+
+::::solution
+```shell
+pkg> add Dates
+pkg> status
+pkg> code -r Project.toml Manifest.toml
+pkg> remove Dates
+```
+::::
+:::
+
+
+
+
+### Activating the default environment again
+
+Sometimes you may wish to return to using the default environment for your Julia version.
+
+If your version is e.g. `1.11` then the command would look like:
+```shell
+pkg> activate @v1.11
+```
+
+:::callout
+Note the `@` symbol before the environment name. This tells us that it is a "shared" environment. That means it can be loaded by name (i.e. without specifying the path to the `Project.toml` file explicitly. You can make your own shared environments for various reasons but that is beyond the scope of the present lesson.
+:::
+
+You can also simply type `activate` with no arguments and Julia will also return to the default environment.
+
 
 ### Temporary environments
 
@@ -189,9 +224,20 @@ code -r Project.toml
 We see that this is empty (no dependencies), confirming that the project has not been affected by changes made to the temp environment.
 
 
+
 ### Using another project
 
-In the case where you have received only a `Project.toml` and `Manifest.toml` file but have not yet installed any dependencies (perhaps because someone has shared their code with you), you can use the `pkg> instantiate` command to install exactly the packages specified in the `Manifest.toml`. This is because using `pkg> activate` will not automatically fetch missing dependencies for you. `pkg> instantiate` will not do anything if you already have everything you need, so it is safe to use.
+Simply activating a project does not actually make Julia download and install any dependencies that may be listed in `Project.toml` (and `Manifest.toml`) but are missing on your machine.
+
+You may have this sitation if someone you are developing with has added a new dependency to the package, or shared their `Manifest.toml` with you.
+
+In such a case, you can make Julia fetch and install any dependencies you need using the `pkg> instantiate` command, to install exactly the packages specified in the `Manifest.toml`.
+
+```shell
+pkg> instantiate
+```
+
+`pkg> instantiate` will not do anything if you already have everything you need, so it is safe to use.
 
 
 ::: keypoints

--- a/episodes/070-pkg.md
+++ b/episodes/070-pkg.md
@@ -20,13 +20,6 @@ title: Packages and environments
 - pkg> activate @place
 :::
 
-::: keypoints
-- Julia has a built-in package manager called `Pkg`.
-- The package manager is usually accessed from the REPL, by pressing `]`.
-- `Project.toml` lists the dependencies of a package.
-- `Manifest.toml` specifies a completely reproducible environment with exact versions.
-:::
-
 
 In general software development, it often makes sense to make use of existing packages rather than implementing everything yourself. The Julia world is no different, and provides a standard way to manage this, via the `Pkg` system.
 
@@ -173,4 +166,9 @@ We see that this is empty (no dependencies), confirming that the project has not
 In the case where you have received only a `Project.toml` and `Manifest.toml` file but have not yet installed any dependencies (perhaps because someone has shared their code with you), you can use the `pkg> instantiate` command to install exactly the packages specified in the `Manifest.toml`. This is because using `pkg> activate` will not automatically fetch missing dependencies for you. `pkg> instantiate` will not do anything if you already have everything you need, so it is safe to use.
 
 
-
+::: keypoints
+- Julia has a built-in package manager called `Pkg`.
+- The package manager is usually accessed from the REPL, by pressing `]`.
+- `Project.toml` lists the dependencies of a package.
+- `Manifest.toml` specifies a completely reproducible environment with exact versions.
+:::

--- a/episodes/070-pkg.md
+++ b/episodes/070-pkg.md
@@ -27,3 +27,150 @@ title: Packages and environments
 - `Manifest.toml` specifies a completely reproducible environment with exact versions.
 :::
 
+
+In general software development, it often makes sense to make use of existing packages rather than implementing everything yourself. The Julia world is no different, and provides a standard way to manage this, via the `Pkg` system.
+
+In the following, we will explore using the Julia REPL to set up a project and manage adding dependencies.
+
+## Make a new project
+
+We will first make a directory and move to it:
+```shell
+mkdir Dummy
+cd Dummy
+```
+
+We open the Julia REPL and enter `pkg` mode by pressing `]`:
+
+```shell
+julia
+julia> # press ]
+pkg>
+```
+In this mode, we can run a variety of commands for managing our project's dependencies.
+
+First we will use `pkg> status` to check what the current situation is, according to Julia:
+```shell
+pkg> status
+```
+
+The output gives us details about the current environment we are using. There will be a list of any dependencies that have been installed, and their versions.
+
+The first line of output may look something like this:
+```output
+Status `~/.julia/environments/v1.11/Project.toml`
+```
+
+This shows the path to the current environment definition, which is in a file called `Project.toml` (we will discuss this later). From the path we see that this is the default environment for our version of Julia (in the above case, `v1.11`). This is the environment that will be used unless the user specifies a different one.
+
+In practice, we generally make specific environments for specific projects. This avoids issues of multiple/clashing versions of dependencies, removes unused dependencies (keeping the project environemtn clean) and allows you to easily publish your project as a package, if desired.
+
+Therefore, let us indicate to Julia that we wish to use an environment for our `Dummy` project. We do this using the `pkg> activate` command:
+
+```shell
+pkg> activate .
+```
+Note that the `.` is important here, as we are supplying a path as an argument to `activate`. This tells Julia that we want to use the current (`./`) directory as a location for a project.
+Julia will confirm that you are activating a new project at your current location (the `Dummy/` directory).
+
+As before, we can use `pkg> status` at any time to check what environment we are in:
+
+```shell
+pkg> status
+```
+
+This will now output "Status" followed by a path to the `Dummy/` directory. This indicates that we have successfully begun working in an environment based there.
+
+The output also indicates that this is an `(empty project)`. This is because we have not added any dependencies yet.
+
+
+## Adding dependencies to your project
+
+If we wish to use functionality of another package in our code, we can add it as a dependency of our project. For example, let us say we wish to add Julia's `Random` package as a dependency. We can do this using `pkg> add`:
+
+```shell
+pkg> add Random
+```
+
+Julia will now download a version of this package and pre-compile it.
+
+```shell
+pkg> status
+```
+
+Running `pkg> status` now will list 'Random' as a dependency, instead of showing "(empty project)" as it did before.
+
+You may notice that a line in the output also indicates that a `Project.toml` file has been updated.
+
+
+## `Project.toml` and `Manifest.toml`
+
+Looking in the previously empty `Dummy/` directory, you should now see the appearance of two files: `Project.toml` and `Manifest.toml`.
+
+From the terminal, you can open these in your currently running vscode window using `code -r`:
+```shell
+code -r Project.toml Manifest.toml
+```
+
+Inspecting `Project.toml`, we see that it has a `[deps]` section, which stands for "dependencies". There is a single dependency, `Random`, along with a long string of letters and numbers. This is the Universally Unique Identifier (UUID) of the package. This will be covered in a later episode.
+
+Next, we inspect `Manifest.toml`. Initially, we see that it contains some information that is similar to the contents of `Project.toml`. We see the `Random` package we added earlier, and its UUID, but
+now also a specific version for that package.
+
+So both `Project.toml` and `Manifest.toml` appear to specify the dependencies of the project. Generally speaking, dependencies may have many versions which may be acceptable (compatible). `Project.toml` gives the requirements of the project on a comparatively high-level, whereas `Manifest.toml` specifies exact versions for each dependency, as well as a hash of the entire project. Therefore, `Manifest.toml` specifies a particular working installation of the package. For most projects, many `Manifest.toml` configurations could be possible.
+
+Note: As the comment at the top of `Manifest.toml` states, the file is automatically generated and should generally not be edited directly.
+
+
+### Removing dependencies
+
+If a dependency was added by mistake, or if we no longer need it, we may wish to remove it. In our case, we only added the `Random` package as an example - we have no plans to use it. So let's remove it as a dependency.
+
+```shell
+pkg> remove Random
+```
+
+If we check `pkg> status` again, we see that we have returned to the "(empty project)" state. Similarly, looking inside `Project.toml` we see that the dependency has indeed disappeared from the project.
+
+```shell
+pkg> status
+```
+
+
+### Temporary environments
+
+In some cases, you may wish to work with a "throwaway" environment - one in which you can add dependencies without it affecting your current project.
+
+You can do this using `pkg> activate --temp`:
+
+```shell
+pkg> activate --temp
+```
+
+This will output something like `Activating new project at `/tmp/jl_4xvh88`.
+
+You can now work with this as with any other environment, but without the fear that changes you make are messing up the `Project.toml` of the project you are working on.
+
+As an example, let's add the `Random` package again.
+```shell
+pkg> status
+pkg> add Random
+pkg> status
+```
+
+We see that `Random` is installed in our temporary environment.
+
+We can now exit the Julia REPL and open our `Project.toml` file as before:
+```shell
+code -r Project.toml
+```
+
+We see that this is empty (no dependencies), confirming that the project has not been affected by changes made to the temp environment.
+
+
+### Using another project
+
+In the case where you have received only a `Project.toml` and `Manifest.toml` file but have not yet installed any dependencies (perhaps because someone has shared their code with you), you can use the `pkg> instantiate` command to install exactly the packages specified in the `Manifest.toml`. This is because using `pkg> activate` will not automatically fetch missing dependencies for you. `pkg> instantiate` will not do anything if you already have everything you need, so it is safe to use.
+
+
+

--- a/episodes/070-pkg.md
+++ b/episodes/070-pkg.md
@@ -102,13 +102,41 @@ Looking in the previously empty `Dummy/` directory, you should now see the appea
 
 From the terminal, you can open these in your currently running vscode window using `code -r`:
 ```shell
-code -r Project.toml Manifest.toml
+code -r Project.toml
+```
+
+```output
+[deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ```
 
 Inspecting `Project.toml`, we see that it has a `[deps]` section, which stands for "dependencies". There is a single dependency, `Random`, along with a long string of letters and numbers. This is the Universally Unique Identifier (UUID) of the package. This will be covered in a later episode.
 
-Next, we inspect `Manifest.toml`. Initially, we see that it contains some information that is similar to the contents of `Project.toml`. We see the `Random` package we added earlier, and its UUID, but
-now also a specific version for that package.
+Next, we inspect `Manifest.toml`.
+
+```shell
+code -r Manifest.toml
+```
+
+```output
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.3"
+manifest_format = "2.0"
+project_hash = "fa3e19418881bf344f5796e1504923a7c80ab1ed"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+```
+
+Initially, we see that it contains some information that is similar to the contents of `Project.toml`. We see the `Random` package we added earlier, and its UUID, but
+now also a specific version for that package. We also a dependency of the `Random` package itself.
 
 So both `Project.toml` and `Manifest.toml` appear to specify the dependencies of the project. Generally speaking, dependencies may have many versions which may be acceptable (compatible). `Project.toml` gives the requirements of the project on a comparatively high-level, whereas `Manifest.toml` specifies exact versions for each dependency, as well as a hash of the entire project. Therefore, `Manifest.toml` specifies a particular working installation of the package. For most projects, many `Manifest.toml` configurations could be possible.
 

--- a/episodes/080-package-development.md
+++ b/episodes/080-package-development.md
@@ -1,22 +1,320 @@
 ---
-title: Package development
+title: Best Practices in Package development
 ---
 
 ::: questions
+- How do I generate a new Julia package that follows best practices?
 - What is the best workflow for developing a Julia package?
 - How can I prevent having to recompile every time I make a change?
 :::
 
 ::: objectives
-- Quick start with pkg> generate
+- Quick start with using the BestieTemplate to generate a package
 - Basic structure of a package
-- VSCode
 - Revise.jl
 :::
 
+
+We will use a Julia template called `BestieTemplate`. The template code can be found on `GitHub`: <https://github.com/JuliaBesties/BestieTemplate.jl>.
+
+Using the template automates the process of setting up the Julia package structure and adding all the small files and tools to help with applying best practices.
+
+## Installing `BestieTemplate.jl`
+
+In order to use `BestieTemplate` to create our new package, we first need to install it.
+
+Open the `Julia` interpreter and enter `pkg` mode by pressing `]`. Then use `add` as we have done in previous exercises:
+
+```shell
+julia> # press ]
+pkg> add BestieTemplate
+```
+
+This might take a couple of minutes to download.
+
+## Generating a fresh new Julia package
+
+We then use the `BestieTemplate` package to generate a new (empty) package at the specified path.
+
+```shell
+pkg> # Press backspace to get out of pkg mode
+julia> using BestieTemplate
+julia> BestieTemplate.generate("MyPackage.jl")
+```
+
+:::callout
+It is actually posible to apply this template to existing packages too:
+```shell
+BestieTemplate.apply("path/to/YourExistingPackage.jl")
+```
+However, for clarity we generate a completely new package in this lesson.
+:::
+
+
+You will now be presented with a series of questions, some required and some optional.
+
+1. Firstly you will be asked to choose a universally unique identifier (UUID) for the new package. This is a label to uniquely identify your package, thus avoiding relying on the package name (identically named packages are fairly likely to occur in a programming community). Luckily, `BestieTemplate` has auto-generated one for you. Press enter to select it.
+
+2. Type in your GitHub username, if you have one. If you don't, then make one up as it does not really matter for this example. This allows BestieTemplate.jl to correctly generate URLs to your (potential) package repository (Julia typically expects packages to be on GitHub)
+
+3. Add the comma separated list of authors. You can type your own name and email here.
+
+4. Add the minimum Julia version that will be supported by your new package. BestieTemplate automatically suggests the latest Long Term Support (LTS) version, so we will press enter to use that one.
+
+5. Choose a license for your package. This is up to the user. Use the arrow keys to select e.g. `Apache-2.0`.
+
+6. Add the names of the copyright holders - again, this should be pre-filled with the name you typed earlier.
+
+You will then be provided with the option to only answer a small number of 'Recommended' questions (first choice). Select this and choose the default (pre-filled) values for each.
+
+Your new package structure will now be created, with configuration files set up according to the answers provided to the previous questions.
+
+
+## Structure of your new (empty) package
+
+* `.copier-answers.yml`
+Here you can see the answers you provided when setting up your package with the `BestieTemplate`.
+
+* `Project.toml`
+The `Project.toml` file specifies the name of our package, UUID and authors (as given in our answers when setting up the template). It also specifies the package's current version
+and dependencies.
+
+* `README.md`
+Standard place to document the purpose of the package, installation instructions, links to more extensive documentation etc.
+
+* `CODE_OF_CONDUCT.md`
+A clear description about how contributors are expected to behave and what processes are available in the event of a breach of conduct.
+
+* `LICENSE`
+Contains the text for the software license you chose for this package.
+
+* `CITATION.cff`
+Stores any authors or contributors to the package, allowing the software itself to be citable.
+
+* Formatting tool configuration files: `.JuliaFormatter.toml`, `.pre-commit-config.yaml`, `.yamllint.yml`, `.markdownlint.json`
+These configure the behaviour of linters and other code-style enforcement tools. They are important for keeping a clean and tidy code base.
+
+* `src/`
+The location of source code files.
+
+* `test/`
+The location of unit tests for the code in this package.
+
+* `docs/`
+The location of scripts for automatically building documentation for the functions in your package (e.g. based on docstrings). In the `docs/src/` directory you can also see some documentation pages explaining how to contribute to the package.
+
+* `.github/`
+This will only come into use if you push your package to GitHub. This directory contains some automated workflows that do things like run tests, build documentation etc.
+
+
+### Activating the generated package
+
+Now that we have generated our new package and inspected its contents and structure, we would like to use it.
+
+In the shell, let's enter the the directory of the new package, and open the `Julia` REPL:
+```shell
+cd MyPackage.jl/
+julia
+```
+
+We will start by checking what environment we are actually currently using. We do this with the `pkg> status` command:
+```shell
+julia> # press ]
+pkg> status
+```
+
+The output will show something like the following:
+```output
+Status `~/.julia/environments/v1.11/Project.toml`
+```
+
+This tells us that we are currently using the base environment for the currently installed `Julia` version (in the above case, `v1.11`. In a sense, you can think of this as the "default" or "global" environment used by `Julia`, if no other has been specified by the user.
+
+The output of `pkg> status` will also output the dependencies (and precise versions) that are currently installed in that environment. For example, you should see the `BestieTemplate` package that we installed earlier to generate our new package.
+
+But we don't currently want this environment. We would like to use, and work on, our new project. We do this by "activating" it:
+```shell
+pkg> activate .
+```
+
+Now let us check the `pkg` status again:
+```shell
+pkg> status
+```
+
+The output should now show `Project MyPackage v0.1.0`, indicating that we are indeed using our new package.
+The "Status" line will also now give the path to the `MyPackage.jl`'s `Project.toml`, which is another sign that everything is in order. However, the end of the line will say `(empty project)`, because there are currently no dependencies of our package.
+
+
+### Adding dependencies 
+
+As before, we can try adding the `Random` package.
+
+```shell
+pkg> add Random
+```
+
+Checking the new contents of `Project.toml`, we see that a `[deps]` section has appeared:
+```output
+[deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+```
+This shows that the `Random` package is a dependency of our package, and also specifies the UUID that precisely identifies the package. Remember that our package, `MyPackage.jl` also has such a UUID.
+
+Running `pkg> status` again will now also list this dependency, instead of "(empty project)".
+
+You should now see that a `Manifest.toml` file is also in the package directory. In this file, you should see something like the following:
+
+```output
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.3"
+manifest_format = "2.0"
+project_hash = "edf6df7b02a39be5254eb0c7ce37b253a09a1e4c"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+```
+
+As before, we can now remove this `Random` package because we do not need it.
+
+```shell
+pkg> remove Random
+```
+
+If we check `pkg> status` again, we see that we have returned to the "(empty project)" state. Similarly, looking inside `Project.toml` we see that the dependency has indeed disappeared from the project.
+
+
+## Developing the package
+
+Now that we have our empty package set up, we would like to develop some code for it!
+
+Navigate to `src/MyPackage.jl` to see some dummy code has already been generated by the template:
+```julia
+module MyPackage
+
+"""
+    hi = hello_world()
+A simple function to return "Hello, World!"
+"""
+function hello_world()
+    return "Hello, World!"
+end
+
+end
+```
+
+In the REPL we can try running this:
+```shell
+julia> using MyPackage
+julia> MyPackage.hello_world()
+```
+
+```output
+"Hello, World!"
+```
+
+Note that we needed `using MyPackage` to tell Julia to make the name `MyPackage` available for us to refer to. We then called the `hello_world` function that is part of that module.
+
+
+:::challenge
+
+### The world is not enough
+
+But perhaps the "World" is not inclusive enough. Let's try saying hello to the whole universe. Try modifying the function to say "Hello, Universe!" then call it in the REPL again.
+
+Before doing this - what do you think the result will be?
+
+::::solution
+
+```julia
+function hello_world()
+    return "Hello, Universe!"
+end
+```
+
+```shell
+julia> MyPackage.hello_world()
+```
+
+```output
+"Hello, World!"
+```
+
+Why did this happen? The answer is that Julia is using the version of the package as it existed when it was first loaded. The modifications you have made have not been tracked or recompiled, so the original function is still being called.
+
+If you reload Julia (exit then open the REPL again) and try again, you will see the result now says "Universe" as desired.
+
+Change the message back to `Hello, World!` for now.
+
+::::
+:::
+
+
+Julia uses the package `MyPackage` in whatever state it is when `using` is first called. Subsequent changes to the source code do not trigger automatic recompilation, unless e.g. Julia is restarted. This is problematic since, during development, we often want to make changes to our code without restarting the Julia session to check it. We can achieve this with `Revise.jl`.
+
+
+### Installing `Revise.jl`
+
+Make sure you are in the default environment when you install `Revise.jl`, as we generally do not want developer dependencies to be a part of the package. Anything you install in the default shared environment will be available in specific environments too due to what is called "environment stacking".
+
+```shell
+pkg> activate # No argument, so as to pick the default environment
+pkg> status
+pkg> add Revise
+```
+
+### Trying out `Revise.jl`
+
+Now we are ready to try out `Revise`. Exit the Julia REPL and reload it, then indicate we wish to use `Revise`.
+
+```shell
+julia
+julia> using Revise
+pkg> activate . # Start using our local package environment again
+```
+
+:::callout
+You must load `Revise` _before_ loading any packages you want it to track.
+:::
+
+Try loading and using our package again.
+
+```shell
+julia> using MyPackage
+julia> MyPackage.hello_world()
+```
+
+```output
+"Hello, World!"
+```
+
+Now try editing the message to say `Goodbye, World!`. Remember to save your changes.
+
+```shell
+julia> MyPackage.hello_world()
+```
+
+```output
+"Goodbye, World!"
+```
+
+Now, thanks to `Revise`, the change to the package's code was being tracked and was automatically recompiled. This means you can make changes to the package and have them be active without needing to reload the Julia REPL.
+
+:::callout
+While `Revise` does its best to track any changes made, there are some limits to what can be done in a single Julia session. For example, changes to type definitions or `const`s (among others) will probably still necessitate restarting your Julia session.
+:::
+
+
+
 ::: keypoints
-- Currently, the editor with (by far) the best support is VSCode.
+- You can use the `BestieTemplate` to generate a new package structure complete with tooling for best practices in Julia development.
 - The `Revise.jl` module can automatically reload parts of your code that have changed.
 - Best practice: file names should reflect module names.
 :::
-

--- a/episodes/080-package-development.md
+++ b/episodes/080-package-development.md
@@ -1,5 +1,5 @@
 ---
-title: Best Practices in Package development
+title: Package development
 ---
 
 ::: questions

--- a/episodes/090-best-practices.md
+++ b/episodes/090-best-practices.md
@@ -15,8 +15,26 @@ title: Best practices
 - documentation
 - GitHub workflows
 - JuliaFormatter.jl
-- BestieTemplate.jl
 :::
+
+
+In this lesson, we will cover issues of best practices in Julia package development. In particular, this covers testing, documentation and formatting.
+
+If you followed the instructions from the previous lesson (using the `BestieTemplate` to generate a package) then all these topics have already been handled.
+
+We will start with adding a new function to our `MyPackage.jl` package, and show how to quickly add unit tests and documentation.
+
+## Preparing for developing
+
+As before, we open the Julia REPL, activate our package and load `Revise`:
+```shell
+julia
+julia> activate .
+julia> using Revise
+```
+
+
+## The roots of a cubic polynomial
 
 The following is a function for computing the roots of a cubic polynomial
 
@@ -59,6 +77,154 @@ function cubic_roots(a, b, c, d)
 	return (0.0+0.0im, cNaN, cNaN)
 end
 ```
+
+We would like to add the above `cubic_roots()` function to the `MyPackage.jl` package.
+
+Add it to the `src/MyPackage.jl` file and save.
+
+Let us load our package and attempt to use the `cubic_roots()` function:
+
+```shell
+julia> using MyPackage
+julia> MyPackage.cubic_roots(1,1,1,1)
+```
+
+```output
+(-1.0 - 0.0im, -3.700743415417188e-17 - 1.0im, -9.25185853854297e-17 + 1.0im)
+```
+
+We see that it is indeed returning some roots to the equation we defined: $$x^3 + x^2 + x + 1 = 0.$$
+
+
+### Testing
+
+#### Testing `hello_world()`
+If we are to develop our package further, we may worry that any changes we make might break existing functionality. For this reason, it is important to add automated tests that can tell us immediately if the behaviour of our existing functions has changed.
+
+In the `test/` directory of `MyPackage.jl` you should see that there already exists an example test for the `hello_world()` function, in `test-basic-test.jl`:
+```julia
+@testset "MyPackage.jl" begin
+    @test MyPackage.hello_world() == "Hello, World!"
+end
+```
+
+`@testset` is used to define a suite of many tests, while `@test` defines a single check. In this case, there is one test and it checks that the `hello_world()` function indeed returns "Hello, World!".
+
+#### Running the tests
+
+We first need to add the standard Julia `Test` package:
+```shell
+pkg> add Test
+```
+
+Then we can run all tests for our package by simply typing `test`:
+```shell
+pkg> test
+```
+
+The outcome of our `hello_world()` test now will depend on what state the `hello_world()` function is currently in. If you modified it in the previous lesson and it no longer returns "Hello, World!", then the test will fail. Try changing the function to make the tests fail and then pass again.
+
+:::challenge
+#### Add a test for `cubic_roots`
+
+Create a new file in the `test/` directory, called `test-cubic.jl`.
+
+Using what you know from the `hello_world()` tests, can you populate this file with a test for the following case:
+
+* For the special case with $$a=0, b=0, c=0, d=0$$ check that the only (non-NaN) solution is 0.
+
+Hint: You only need to check the first element of the returned tuple.
+
+
+::::solution
+
+The contents of `test-cubic.jl` should be e.g.
+```julia
+@testset "MyPackage.jl" begin
+    @test MyPackage.cubic_roots(0,0,0,0)[1] == 0
+end
+```
+
+Then, running `pkg> test` will result in a pass.
+
+Note that the equality check would also work with:
+```julia
+    @test MyPackage.cubic_roots(0,0,0,0)[1] == 0.0
+```
+and
+```julia
+    @test MyPackage.cubic_roots(0,0,0,0)[1] == 0.0+0.0im
+```
+
+::::
+:::
+
+### Documentation
+
+#### Documenting `hello_world()`
+
+The `hello_world()` function has a docstring before it:
+```julia
+"""
+    hi = hello_world()
+A simple function to return "Hello, World!"
+"""
+```
+This is low-level technical documentation for this particular function. 
+
+#### Using the REPL help mode
+In the Julia REPL, pressing `?` will enter help mode. You can then type the name of a function you would like documentation about:
+```shell
+julia> # Press '?'
+help?> MyPackage.hello_world()
+```
+
+```output
+
+  │ Warning
+  │
+  │  The following bindings may be internal; they may change or be removed in future versions:
+  │
+  │    •  MyPackage.hello_world
+
+  hi = hello_world()
+
+  A simple function to return "Hello, World!"
+```
+
+
+#### Building the docs
+The standard package for building beautiful documentation websites for Julia packages is `Documenter.jl`. It can be seen in the `Project.toml` for the `docs/` directory that this is indeed the package that `BestieTemplate.jl` has set up for us.
+
+In `docs/make.jl` we see `Documenter` being used to build the documentation website, that is then deployed to GitHub Pages where it is served from.
+
+However, presently the code makes a lot of assumptions about being used with git on GitHub, and local builds tend not to render nicely. For a taste of how it looks when fully rendered, see e.g. <https://partitionedarrays.github.io/PartitionedArrays.jl/stable/>.
+
+### Formatting
+A good automatic formatter for Julia is `JuliaFormatter.jl`
+
+```shell
+pkg> add JuliaFormatter
+julia> using JuliaFormatter
+```
+
+Then you can try it out on our source file:
+
+```shell
+julia> format("src/MyPackage.jl")
+```
+
+Not a huge amount will change, but you may notice that spaces are inserted around arithmetic operators, for example:
+```
+cNaN = NaN+NaN*im
+```
+becomes
+```
+cNaN = NaN + NaN * im
+```
+
+The configuration for the formatting in our package is set in `.JuliaFormatter.toml`. In practice, you will not run this formatter manually, but it will be automated by workflows created by the `BestieTemplate`. This course does not focus on these (largely they are integrated with `git` and `GitHub`) but they are helpful with ensuring a clean code base with minimal effort.
+
 
 ::: keypoints
 - Julia has integrated support for unit testing.


### PR DESCRIPTION
Here's a first draft of three episodes. These cover how to use `pkg>`, how to generate a new package with `BestieTemplate` (and various considerations around that), how and why to use `Revise.jl`, and how to do unit testing, documentation and formatting.

I've been testing the rendering locally, and it seems to be ok.

My main issue with the content is that I really wanted to get the students to use `Documenter` to build the documentation locally so they could see it themselves. Unfortunately, `BestieTemplate` is very integrated with git/github, and Documenter is quite annoying (and whiny) when building locally without a git repo, so the commands are going to look rather verbose and cryptic if we type them out during teaching. Also, even when I get it to build, I think I still need to serve it locally (otherwise the pages render in an ugly and broken way). Honestly I don't think it's worth it and we can just show an example of what it looks like for an existing project.

If you know an easy/reliable way to do this then please tell me though. I'm fairly new to Julia so it's likely I just misunderstood something.